### PR TITLE
feat: add extra ticker fields for all supported exchanges

### DIFF
--- a/cryptofeed/callback.py
+++ b/cryptofeed/callback.py
@@ -45,8 +45,8 @@ class TradeCallback(Callback):
 
 
 class TickerCallback(Callback):
-    async def __call__(self, *, feed: str, symbol: str, bid: Decimal, ask: Decimal, timestamp: float, receipt_timestamp: float):
-        await super().__call__(feed, symbol, bid, ask, timestamp, receipt_timestamp)
+    async def __call__(self, *, feed: str, symbol: str, bid: Decimal, ask: Decimal, bbo: dict, timestamp: float, receipt_timestamp: float, **kwargs):
+        await super().__call__(feed, symbol, bid, ask, bbo, timestamp, receipt_timestamp, **kwargs)
 
 
 class BookCallback(Callback):

--- a/cryptofeed/exchange/binance.py
+++ b/cryptofeed/exchange/binance.py
@@ -140,12 +140,24 @@ class Binance(Feed):
         else:
             ts = timestamp
 
+        # 24hr rolling window, note: these are not available for the realtime "bookTicker" stream
+        extra_fields = {
+            'high': Decimal(msg.get('h', 0)),
+            'low': Decimal(msg.get('l', 0)),
+            'last': Decimal(msg.get('c', 0)),
+            'last_size': Decimal(msg.get('Q', 0)),
+            'volume': Decimal(msg.get('v', 0)),
+            'best_bid_size': Decimal(msg.get('B', 0)),
+            'best_ask_size': Decimal(msg.get('A', 0)),
+        }
         await self.callback(TICKER, feed=self.id,
                             symbol=pair,
                             bid=bid,
                             ask=ask,
+                            bbo=self.get_book_bbo(pair),
                             timestamp=ts,
-                            receipt_timestamp=timestamp)
+                            receipt_timestamp=timestamp,
+                            **extra_fields)
 
     async def _liquidations(self, msg: dict, timestamp: float):
         """

--- a/cryptofeed/exchange/bitcoincom.py
+++ b/cryptofeed/exchange/bitcoincom.py
@@ -57,12 +57,22 @@ class BitcoinCom(Feed):
                                 receipt_timestamp=timestamp)
 
     async def _ticker(self, msg: dict, timestamp: float):
+        symbol = symbol_exchange_to_std(msg['symbol'])
+        # 24h rolling window
+        extra_fields = {
+            'high': Decimal(msg.get('high', 0)),
+            'low': Decimal(msg.get('low', 0)),
+            'last': Decimal(msg.get('last', 0)),
+            'volume': Decimal(msg.get('volume', 0)),
+        }
         await self.callback(TICKER, feed=self.id,
-                            symbol=symbol_exchange_to_std(msg['symbol']),
+                            symbol=symbol,
                             bid=Decimal(msg['bid']),
                             ask=Decimal(msg['ask']),
+                            bbo=self.get_book_bbo(symbol),
                             timestamp=timestamp_normalize(self.id, msg['timestamp']),
-                            receipt_timestamp=timestamp)
+                            receipt_timestamp=timestamp,
+                            **extra_fields)
 
     async def _book_snapshot(self, msg: dict, timestamp: float):
         pair = symbol_exchange_to_std(msg['symbol'])

--- a/cryptofeed/exchange/bitfinex.py
+++ b/cryptofeed/exchange/bitfinex.py
@@ -67,13 +67,21 @@ class Bitfinex(Feed):
             return  # ignore heartbeats
         # bid, bid_size, ask, ask_size, daily_change, daily_change_percent,
         # last_price, volume, high, low
-        bid, _, ask, _, _, _, _, _, _, _ = msg[1]
+        bid, _, ask, _, _, _, last_price, volume, high, low = msg[1]
+        extra_fields = {
+            'high': Decimal(high),
+            'low': Decimal(low),
+            'last': Decimal(last_price),
+            'volume': Decimal(volume),
+        }
         await self.callback(TICKER, feed=self.id,
                             symbol=pair,
                             bid=bid,
                             ask=ask,
+                            bbo=self.get_book_bbo(pair),
                             timestamp=timestamp,
-                            receipt_timestamp=timestamp)
+                            receipt_timestamp=timestamp,
+                            **extra_fields)
 
     async def _funding(self, pair: str, msg: dict, timestamp: float):
         async def _funding_update(funding: list, timestamp: float):

--- a/cryptofeed/exchange/bitmex.py
+++ b/cryptofeed/exchange/bitmex.py
@@ -136,12 +136,19 @@ class Bitmex(Feed):
 
     async def _ticker(self, msg: dict, timestamp: float):
         for data in msg['data']:
+            symbol = symbol_exchange_to_std(data['symbol'])
+            extra_fields = {
+                'best_bid_size': Decimal(data.get('bidSize', 0)),
+                'best_ask_size': Decimal(data.get('askSize', 0)),
+            }
             await self.callback(TICKER, feed=self.id,
-                                symbol=symbol_exchange_to_std(data['symbol']),
+                                symbol=symbol,
                                 bid=Decimal(data['bidPrice']),
                                 ask=Decimal(data['askPrice']),
+                                bbo=self.get_book_bbo(symbol),
                                 timestamp=timestamp_normalize(self.id, data['timestamp']),
-                                receipt_timestamp=timestamp)
+                                receipt_timestamp=timestamp,
+                                **extra_fields)
 
     async def _funding(self, msg: dict, timestamp: float):
         """

--- a/cryptofeed/exchange/coinbase.py
+++ b/cryptofeed/exchange/coinbase.py
@@ -88,12 +88,22 @@ class Coinbase(Feed):
             'last_size': '0.00241692'
         }
         '''
+        symbol = symbol_exchange_to_std(msg['product_id'])
+        extra_fields = {
+            'high': Decimal(msg.get('high_24h', 0)),
+            'low': Decimal(msg.get('low_24h', 0)),
+            'volume': Decimal(msg.get('volume_24h', 0)),
+            'last': Decimal(msg.get('price', 0)),
+            'last_size': Decimal(msg.get('last_size', 0)),
+        }
         await self.callback(TICKER, feed=self.id,
-                            symbol=symbol_exchange_to_std(msg['product_id']),
+                            symbol=symbol,
                             bid=Decimal(msg['best_bid']),
                             ask=Decimal(msg['best_ask']),
+                            bbo=self.get_book_bbo(symbol),
                             timestamp=timestamp_normalize(self.id, msg['time']),
-                            receipt_timestamp=timestamp)
+                            receipt_timestamp=timestamp,
+                            **extra_fields)
 
     async def _book_update(self, msg: dict, timestamp: float):
         '''

--- a/cryptofeed/exchange/ftx.py
+++ b/cryptofeed/exchange/ftx.py
@@ -194,12 +194,18 @@ class FTX(Feed):
         {"channel": "ticker", "market": "BTC/USD", "type": "update", "data": {"bid": 10717.5, "ask": 10719.0,
         "last": 10719.0, "time": 1564834587.1299787}}
         """
+        symbol = symbol_exchange_to_std(msg['market'])
+        extra_fields = {
+            'last': msg['data'].get('last'),
+        }
         await self.callback(TICKER, feed=self.id,
-                            symbol=symbol_exchange_to_std(msg['market']),
+                            symbol=symbol,
                             bid=Decimal(msg['data']['bid'] if msg['data']['bid'] else 0.0),
                             ask=Decimal(msg['data']['ask'] if msg['data']['ask'] else 0.0),
+                            bbo=self.get_book_bbo(symbol),
                             timestamp=float(msg['data']['time']),
-                            receipt_timestamp=timestamp)
+                            receipt_timestamp=timestamp,
+                            **extra_fields)
 
     async def _book(self, msg: dict, timestamp: float):
         """

--- a/cryptofeed/exchange/hitbtc.py
+++ b/cryptofeed/exchange/hitbtc.py
@@ -28,12 +28,21 @@ class HitBTC(Feed):
         self.seq_no = {}
 
     async def _ticker(self, msg: dict, timestamp: float):
+        symbol = symbol_exchange_to_std(msg['symbol'])
+        extra_fields = {
+            'high': Decimal(msg.get('high', 0)),
+            'low': Decimal(msg.get('low', 0)),
+            'last': Decimal(msg.get('last') or 0),  # nullable
+            'volume': Decimal(msg.get('volume', 0)),
+        }
         await self.callback(TICKER, feed=self.id,
-                            symbol=symbol_exchange_to_std(msg['symbol']),
-                            bid=Decimal(msg['bid']),
-                            ask=Decimal(msg['ask']),
+                            symbol=symbol,
+                            bid=Decimal(msg['bid'] or 0),  # nullable
+                            ask=Decimal(msg['ask'] or 0),  # nullable
+                            bbo=self.get_book_bbo(symbol),
                             timestamp=timestamp_normalize(self.id, msg['timestamp']),
-                            receipt_timestamp=timestamp)
+                            receipt_timestamp=timestamp,
+                            **extra_fields)
 
     async def _book(self, msg: dict, timestamp: float):
         delta = {BID: [], ASK: []}

--- a/cryptofeed/exchange/kraken.py
+++ b/cryptofeed/exchange/kraken.py
@@ -111,12 +111,21 @@ class Kraken(Feed):
         [93, {'a': ['105.85000', 0, '0.46100000'], 'b': ['105.77000', 45, '45.00000000'], 'c': ['105.83000', '5.00000000'], 'v': ['92170.25739498', '121658.17399954'], 'p': ['107.58276', '107.95234'], 't': [4966, 6717], 'l': ['105.03000', '105.03000'], 'h': ['110.33000', '110.33000'], 'o': ['109.45000', '106.78000']}]
         channel id, asks: price, wholeLotVol, vol, bids: price, wholeLotVol, close: ...,, vol: ..., VWAP: ..., trades: ..., low: ...., high: ..., open: ...
         """
+        m = msg[1]
+        extra_fields = {
+            'high': Decimal(m['h'][1]),     # [1] is 24h
+            'low': Decimal(m['l'][1]),      # [1] is 24h
+            'last': Decimal(m['c'][0]),     # [0] is price
+            'volume': Decimal(m['v'][0]),   # [1] is 24h
+        }
         await self.callback(TICKER, feed=self.id,
                             symbol=pair,
-                            bid=Decimal(msg[1]['b'][0]),
-                            ask=Decimal(msg[1]['a'][0]),
+                            bid=Decimal(m['b'][0]),
+                            ask=Decimal(m['a'][0]),
+                            bbo=self.get_book_bbo(pair),
                             timestamp=timestamp,
-                            receipt_timestamp=timestamp)
+                            receipt_timestamp=timestamp,
+                            **extra_fields)
 
     async def _book(self, msg: dict, pair: str, timestamp: float):
         delta = {BID: [], ASK: []}

--- a/cryptofeed/exchange/kraken_futures.py
+++ b/cryptofeed/exchange/kraken_futures.py
@@ -82,7 +82,21 @@ class KrakenFutures(Feed):
             "maturityTime": 0
         }
         """
-        await self.callback(TICKER, feed=self.id, symbol=pair, bid=msg['bid'], ask=msg['ask'], timestamp=timestamp, receipt_timestamp=timestamp)
+        extra_fields = {
+            'last': Decimal(msg.get('last', 0)),
+            'volume': Decimal(msg.get('volume', 0)),
+            'bid_size': Decimal(msg.get('bid_size', 0)),
+            'ask_size': Decimal(msg.get('ask_size', 0)),
+            'mark_price': Decimal(msg.get('markPrice', 0)),
+        }
+        await self.callback(TICKER, feed=self.id,
+                            symbol=pair,
+                            bid=msg['bid'],
+                            ask=msg['ask'],
+                            bbo=self.get_book_bbo(pair),
+                            timestamp=timestamp,
+                            receipt_timestamp=timestamp,
+                            **extra_fields)
 
     async def _book_snapshot(self, msg: dict, pair: str, timestamp: float):
         """

--- a/cryptofeed/exchange/okcoin.py
+++ b/cryptofeed/exchange/okcoin.py
@@ -106,12 +106,24 @@ class OKCoin(Feed):
         for update in msg['data']:
             pair = update['instrument_id']
             update_timestamp = timestamp_normalize(self.id, update['timestamp'])
+            extra_fields = {
+                'high': Decimal(update.get('high_24h', 0)),
+                'low': Decimal(update.get('low_24h', 0)),
+                'last': Decimal(update.get('last', 0)),
+                'last_size': Decimal(update.get('last_qty', 0)),
+                'volume': Decimal(update.get('base_volume_24h', 0)),
+                'best_bid_size': Decimal(update.get('best_bid_size', 0)),
+                'best_ask_size': Decimal(update.get('best_ask_size', 0)),
+            }
             await self.callback(TICKER, feed=self.id,
                                 symbol=pair,
                                 bid=Decimal(update['best_bid']) if update['best_bid'] else Decimal(0),
                                 ask=Decimal(update['best_ask']) if update['best_ask'] else Decimal(0),
+                                bbo=self.get_book_bbo(pair),
                                 timestamp=update_timestamp,
-                                receipt_timestamp=timestamp)
+                                receipt_timestamp=timestamp,
+                                **extra_fields)
+
             if 'open_interest' in update:
                 oi = update['open_interest']
                 if pair in self.open_interest and oi == self.open_interest[pair]:

--- a/cryptofeed/feed.py
+++ b/cryptofeed/feed.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from functools import partial
 import logging
 import os
+from decimal import Decimal
 from typing import Tuple, Callable, Union, List
 
 from cryptofeed.callback import Callback
@@ -234,6 +235,19 @@ class Feed:
         else:
             await self.callback(L3_BOOK, feed=self.id, symbol=symbol, book=book, timestamp=timestamp, receipt_timestamp=receipt_timestamp)
         self.updates[symbol] = 0
+
+    def get_book_bbo(self, symbol) -> dict:
+        """ Return OrderBook's best bid and offer (including sizes) """
+        try:
+            return {
+                BID: self.l2_book[symbol][BID].peekitem(),
+                ASK: self.l2_book[symbol][ASK].peekitem(0),
+            }
+        except (AttributeError, KeyError):
+            return {
+                BID: (Decimal(), Decimal()),
+                ASK: (Decimal(), Decimal()),
+            }
 
     def check_bid_ask_overlapping(self, book, symbol):
         bid, ask = book[BID], book[ASK]

--- a/cryptofeed/feed.py
+++ b/cryptofeed/feed.py
@@ -243,7 +243,7 @@ class Feed:
                 BID: self.l2_book[symbol][BID].peekitem(),
                 ASK: self.l2_book[symbol][ASK].peekitem(0),
             }
-        except (AttributeError, KeyError):
+        except (AttributeError, KeyError, IndexError):  # Empty OrderBook
             return {
                 BID: (Decimal(), Decimal()),
                 ASK: (Decimal(), Decimal()),

--- a/cryptofeed/standards.py
+++ b/cryptofeed/standards.py
@@ -199,7 +199,7 @@ _feed_to_exchange_map = {
         BITCOINCOM: 'subscribeTicker',
         BITMAX: UNSUPPORTED,
         UPBIT: UNSUPPORTED,
-        GATEIO: UNSUPPORTED,
+        GATEIO: 'ticker.subscribe',
         PROBIT: UNSUPPORTED
     },
     VOLUME: {


### PR DESCRIPTION
### Adds extra ticker fields

- Add generic method to read OrderBook's Best_Bid_Offer to populate bid/ask sizes when not provided by Exchange
- Add Deribit options greeks
- Add High/Low/Last/Volume fields + more where supported

TODO: Add Ticker channel into cryptofeed where it has not been implemented at all.

- [x] - Tested
- [ ] - Changelog updated
- [x] - Tests run and pass (TM: yes except SSL errors)
- [ ] - Flake8 run and all errors/warnings resolved
