### PR TITLE
[Bug/WebSockets] Port a fix for websockets==10.0.0 crashing the websocket APIs of certain exchanges from upstream branch

### DIFF
--- a/cryptofeed/exchange/bitmex.py
+++ b/cryptofeed/exchange/bitmex.py
@@ -57,6 +57,7 @@ class Bitmex(Feed):
     def __init__(self, sandbox=False, **kwargs):
         auth_api = 'wss://www.bitmex.com/realtime' if not sandbox else 'wss://testnet.bitmex.com/realtime'
         super().__init__(auth_api, **kwargs)
+        self.ws_defaults['compression'] = None
         self._reset()
 
     def _reset(self):

--- a/cryptofeed/exchange/bitstamp.py
+++ b/cryptofeed/exchange/bitstamp.py
@@ -39,6 +39,7 @@ class Bitstamp(Feed):
 
     def __init__(self, **kwargs):
         super().__init__('wss://ws.bitstamp.net/', **kwargs)
+        self.ws_defaults['compression'] = None
 
     async def _l2_book(self, msg: dict, timestamp: float):
         data = msg['data']

--- a/cryptofeed/exchange/bybit.py
+++ b/cryptofeed/exchange/bybit.py
@@ -43,6 +43,7 @@ class Bybit(Feed):
 
     def __init__(self, **kwargs):
         super().__init__({'USD': 'wss://stream.bybit.com/realtime', 'USDT': 'wss://stream.bybit.com/realtime_public'}, **kwargs)
+        self.ws_defaults['compression'] = None
 
     def __reset(self, quote=None):
         if quote is None:

--- a/cryptofeed/exchange/ftx.py
+++ b/cryptofeed/exchange/ftx.py
@@ -48,6 +48,7 @@ class FTX(Feed):
 
     def __init__(self, **kwargs):
         super().__init__('wss://ftexchange.com/ws/', **kwargs)
+        self.ws_defaults['compression'] = None
 
     def __reset(self):
         self.l2_book = {}

--- a/cryptofeed/exchange/gateio.py
+++ b/cryptofeed/exchange/gateio.py
@@ -33,6 +33,7 @@ class Gateio(Feed):
 
     def __init__(self, candle_interval='1m', **kwargs):
         super().__init__('wss://api.gateio.ws/ws/v4/', **kwargs)
+        self.ws_defaults['compression'] = None
         if candle_interval == '1w':
             candle_interval = '7d'
         self.candle_interval = candle_interval

--- a/cryptofeed/exchange/okex.py
+++ b/cryptofeed/exchange/okex.py
@@ -54,6 +54,7 @@ class OKEx(OKCoin):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.ws_defaults['compression'] = None
         self.address = 'wss://real.okex.com:8443/ws/v3'
 
     async def _liquidations(self, pairs: list):


### PR DESCRIPTION
I spotted this issue on the upstream repo: https://github.com/bmoscon/cryptofeed/issues/626. It seems to be related to a new version of the `websockets` library crashign on messages that don't conform to the correct standard (and exchange APIs being crap, of course they send this kind of messages...). Out of the impacted exchanges, FTX is the most concerning one. This PR simply ports a workaround added by the upstream owner to our version. Other way to fix would be to set our version of the library to 9.1.0 manually until we can merge the upstream changes in.

Our fork currently requests `websockets>=7.0`, and I expect we are using 9.1.0 in prod because release 10 is pretty new (Sept 9th) and we should have the old one cashed. Still, we're just one (silent) upgrade away from a crash and loss of all FTX market data.