### PR TITLE
feat: perpetual funding rates

### DIFF
--- a/cryptofeed/exchange/binance.py
+++ b/cryptofeed/exchange/binance.py
@@ -308,13 +308,15 @@ class Binance(Feed):
             "T": 1562306400000          // Next funding time
         }
         """
+        interval = 60*60*8  # 8 hour funding interval
         await self.callback(FUNDING,
                             feed=self.id,
                             symbol=self.exchange_symbol_to_std_symbol(msg['s']),
                             timestamp=timestamp_normalize(self.id, msg['E']),
                             receipt_timestamp=timestamp,
                             mark_price=msg['p'],
-                            rate=msg['r'],
+                            interval=interval,
+                            next_funding_rate=Decimal(msg['r']),
                             next_funding_time=timestamp_normalize(self.id, msg['T']),
                             )
     

--- a/cryptofeed/exchange/binance_futures.py
+++ b/cryptofeed/exchange/binance_futures.py
@@ -118,13 +118,15 @@ class BinanceFutures(Binance):
 
         if self._subscribed_to_feed_and_symbol(FUNDING, msg['s']):
             # Subscribed to the non-index symbol and FUNDING. Send an update.
+            interval = 60*60*8      # 8 hour funding rate interval
             await self.callback(FUNDING,
                                 feed=self.id,
                                 symbol=symbol,
                                 timestamp=ts,
                                 receipt_timestamp=timestamp,
                                 mark_price=msg['p'],
-                                rate=msg['r'],
+                                interval=interval,
+                                next_funding_rate=Decimal(msg['r']),
                                 next_funding_time=timestamp_normalize(self.id, msg['T']),
                                 )
 

--- a/cryptofeed/exchange/kraken_futures.py
+++ b/cryptofeed/exchange/kraken_futures.py
@@ -222,17 +222,20 @@ class KrakenFutures(Feed):
 
     async def _funding(self, msg: dict, pair: str, timestamp: float):
         if msg['tag'] == 'perpetual':
+            interval = 60*60*4  # 4 hour funding intervals
+            funding_time = timestamp_normalize(self.id, msg['time'])
             await self.callback(FUNDING,
                                 feed=self.id,
                                 symbol=pair,
                                 timestamp=timestamp_normalize(self.id, msg['time']),
                                 receipt_timestamp=timestamp,
                                 tag=msg['tag'],
-                                rate=msg['funding_rate'],
-                                rate_prediction=msg.get('funding_rate_prediction', None),
-                                relative_rate=msg['relative_funding_rate'],
-                                relative_rate_prediction=msg.get('relative_funding_rate_prediction', None),
-                                next_rate_timestamp=timestamp_normalize(self.id, msg['next_funding_rate_time']))
+                                rate=msg['relative_funding_rate'],  # relative = the rate per hour
+                                funding_time=funding_time,
+                                next_funding_rate=msg.get('relative_funding_rate_prediction', None),
+                                next_funding_time=funding_time + interval,
+                                interval=interval,
+                                )
         else:
             await self.callback(FUNDING,
                                 feed=self.id,
@@ -250,7 +253,7 @@ class KrakenFutures(Feed):
         await self.callback(OPEN_INTEREST,
                             feed=self.id,
                             symbol=pair,
-                            open_interest=msg['openInterest'],
+                            open_interest=msg['openInterest'],  # in number of contracts
                             timestamp=timestamp_normalize(self.id, msg['time']),
                             receipt_timestamp=timestamp
                             )

--- a/cryptofeed/exchange/okcoin.py
+++ b/cryptofeed/exchange/okcoin.py
@@ -185,13 +185,20 @@ class OKCoin(Feed):
 
     async def _funding(self, msg: dict, timestamp: float):
         for update in msg['data']:
+            # OKEx, OKCoin use the previous period's funding rate (`funding_rate`) at the funding time
+            interval = 60*60*8  # 8 hours
+            funding_time = timestamp_normalize(self.id, update['funding_time'])
             await self.callback(FUNDING,
                                 feed=self.id,
                                 symbol=self.exchange_symbol_to_std_symbol(update['instrument_id']),
-                                timestamp=timestamp_normalize(self.id, update['funding_time']),
+                                timestamp=timestamp,
                                 receipt_timestamp=timestamp,
-                                rate=update['funding_rate'],
+                                rate=Decimal(update['funding_rate']),
                                 estimated_rate=update['estimated_rate'],
+                                prev_funding_time=funding_time,
+                                next_funding_rate=Decimal(update['estimated_rate']),
+                                next_funding_time=funding_time + interval,
+                                interval=interval,
                                 settlement_time=timestamp_normalize(self.id, update['settlement_time']))
 
     async def _book(self, msg: dict, timestamp: float):


### PR DESCRIPTION
lots of problems with the existing codebase for perpetual funding rates.

this PR does a lot of work in standardising them, but we may need a few more changes in the future.

some of these exchanges don't provide both previous and predicted rates.

this is the standardised format:
```
  FundingType funding_type     = 9;
  int64 funding_interval       = 10;  // period between funding events in seconds  (not CONTINUOUS)

  double funding_rate          = 20;  // last calculated rate: realtime (CONTINUOUS), previous period (INTERVAL), previous period (INTERVAL_LAGGED)
  int64 funding_timestamp      = 21;  // time to apply funding_rate: now (CONTINUOUS), end of previous period (INTERVAL), end of current period (INTERVAL_LAGGED)

  double next_funding_rate     = 30;  // predicted rate: calculated in current period (INTERVAL and INTERVAL_LAGGED)
  int64 next_funding_timestamp = 31;  // time to apply next_funding_rate: end of current period (INTERVAL), end of next period (INTERVAL_LAGGED)

  double avg_8h_funding_rate   = 40;  // average funding rate over rolling 8-hour window (only CONTINUOUS)

  enum FundingType {
    CONTINUOUS      = 0;  // funding rate is calculated and applied in realtime to unrealised pnl (eg. Deribit)
    INTERVAL        = 1;  // calculated from this current period and applied at the end of the period  (eg. FTX, Bitmex, Binance)
    INTERVAL_LAGGED  = 2;  // calculated from the previous period and applied at the end of the current period (eg. OKEx, KrakenFuts)
  }
```
