### PR TITLE
Fix OKEx order book update bug

### DIFF
--- a/cryptofeed/exchange/okcoin.py
+++ b/cryptofeed/exchange/okcoin.py
@@ -302,8 +302,7 @@ class OKCoin(Feed):
             if is_authenticated_channel(channel):
                 for s in self.subscription[channel]:
                     ret.append((WSAsyncConn(self.address, self.id, **self.ws_defaults), partial(self.user_order_subscribe, symbol=s), self.message_handler, self.authenticate))
-            else:
-                ret.append((WSAsyncConn(self.address, self.id, **self.ws_defaults), self.subscribe, self.message_handler, self.authenticate))
+        ret.append((WSAsyncConn(self.address, self.id, **self.ws_defaults), self.subscribe, self.message_handler, self.authenticate))
 
         return ret
 


### PR DESCRIPTION
## Summary

Fix the errors occurring in the order book update step.

## Description

The cause was that the OKEx exchange class was opening multiple websocket
connections (an erroneous else clause meant that the number of sockets was
determined by the number of channels, and not the number of different URIs).

Multiple websockets meant that the same update messages were being received
multiple times. This was fine as long as the messages were received in order,
as the order book update callback was idempotent and so could handle repeated
messages. The errors occurred when the messages became out of sync and the same
message was received again, after other subsequent updates had already been
processed from another websocket. This is why the errors occurred
intermittently.
