### PR TITLE
fix(connection) reset last_message time when connection is opened

### DIFF
--- a/cryptofeed/connection.py
+++ b/cryptofeed/connection.py
@@ -74,6 +74,7 @@ class AsyncConnection(Connection):
     @asynccontextmanager
     async def connect(self):
         await self._open()
+        self.last_message = None
         try:
             yield self
         finally:


### PR DESCRIPTION
## Summary

The bug was caused by the `last_message` state persisting between connections. This resets the state so that the connect can recover from the bad state that the Binance instrument was finding itself in.